### PR TITLE
Lemmy 0.19 Support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,7 @@ async function main() {
         password: localPassword,
       };
       let user = await localClient.login(loginForm);
+      localClient.setHeaders({Authorization: "Bearer " + user.jwt});
       for await (const remoteInstance of remoteInstances) {
         try {
           for await (const communitySortMethod of communitySortMethods) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "lemmy-js-client": "^0.18.0"
+        "lemmy-js-client": "0.19.0-rc.13"
       }
     },
     "node_modules/asynckit": {
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/lemmy-js-client": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/lemmy-js-client/-/lemmy-js-client-0.18.0.tgz",
-      "integrity": "sha512-FhG2929Cwoh7vHUXC1CuvG0GrNdJmrVhpKbAo+gbGLuHXjkaziX4xfWl1dkuckylVFlloHiST4lXUX2iyvBAog==",
+      "version": "0.19.0-rc.13",
+      "resolved": "https://registry.npmjs.org/lemmy-js-client/-/lemmy-js-client-0.19.0-rc.13.tgz",
+      "integrity": "sha512-JP9oEh1+Wfttqx5O5EMAVIR/hFVS66iVKmEo8/Uxw8fJfyUeQo7BhKvG8LTYegBE39Womgyu3KxXb7Jy9DRI5A==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "form-data": "^4.0.0"
@@ -162,9 +162,9 @@
       }
     },
     "lemmy-js-client": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/lemmy-js-client/-/lemmy-js-client-0.18.0.tgz",
-      "integrity": "sha512-FhG2929Cwoh7vHUXC1CuvG0GrNdJmrVhpKbAo+gbGLuHXjkaziX4xfWl1dkuckylVFlloHiST4lXUX2iyvBAog==",
+      "version": "0.19.0-rc.13",
+      "resolved": "https://registry.npmjs.org/lemmy-js-client/-/lemmy-js-client-0.19.0-rc.13.tgz",
+      "integrity": "sha512-JP9oEh1+Wfttqx5O5EMAVIR/hFVS66iVKmEo8/Uxw8fJfyUeQo7BhKvG8LTYegBE39Womgyu3KxXb7Jy9DRI5A==",
       "requires": {
         "cross-fetch": "^3.1.5",
         "form-data": "^4.0.0"

--- a/src/package.json
+++ b/src/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "lemmy-js-client": "^0.18.0"
+    "lemmy-js-client": "0.19.0-rc.13"
   }
 }


### PR DESCRIPTION
This is a simple change that adds Lemmy 0.19 support to LCS. It is backward compatible to my knowledge.